### PR TITLE
Update image tag to '0.1' to be consistent across all guestbook examples and increased the replicas count to 3

### DIFF
--- a/blue-green/values.yaml
+++ b/blue-green/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 
 image:
   repository: gcr.io/heptio-images/ks-guestbook-demo

--- a/guestbook/guestbook-ui-deployment.yaml
+++ b/guestbook/guestbook-ui-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: guestbook-ui
 spec:
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 3
   selector:
     matchLabels:
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
+      - image: gcr.io/heptio-images/ks-guestbook-demo:0.1
         name: guestbook-ui
         ports:
         - containerPort: 80

--- a/helm-guestbook/values.yaml
+++ b/helm-guestbook/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 
 image:
   repository: gcr.io/heptio-images/ks-guestbook-demo

--- a/jsonnet-guestbook-tla/guestbook-ui.jsonnet
+++ b/jsonnet-guestbook-tla/guestbook-ui.jsonnet
@@ -1,8 +1,8 @@
 function (
     containerPort=80, 
-    image="gcr.io/heptio-images/ks-guestbook-demo:0.2", 
+    image="gcr.io/heptio-images/ks-guestbook-demo:0.1", 
     name="jsonnet-guestbook-ui",
-    replicas=1,
+    replicas=3,
     servicePort=80, 
     type="LoadBalancer"
 )

--- a/jsonnet-guestbook/params.libsonnet
+++ b/jsonnet-guestbook/params.libsonnet
@@ -1,8 +1,8 @@
 {
   containerPort: 80,
-  image: "gcr.io/heptio-images/ks-guestbook-demo:0.2",
+  image: "gcr.io/heptio-images/ks-guestbook-demo:0.1",
   name: "jsonnet-guestbook-ui",
-  replicas: 1,
+  replicas: 3,
   servicePort: 80,
   type: "LoadBalancer",
 }

--- a/ksonnet-guestbook/components/params.libsonnet
+++ b/ksonnet-guestbook/components/params.libsonnet
@@ -8,9 +8,9 @@
     // Each object below should correspond to a component in the components/ directory
     "guestbook-ui": {
       containerPort: 80,
-      image: "gcr.io/heptio-images/ks-guestbook-demo:0.2",
+      image: "gcr.io/heptio-images/ks-guestbook-demo:0.1",
       name: "ks-guestbook-ui",
-      replicas: 1,
+      replicas: 3,
       servicePort: 80,
       type: "LoadBalancer",
     },

--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: guestbook-ui
 spec:
-  replicas: 1
+  replicas: 3
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
Currently, there are two versions available for the image ks-guestbook-demo:

gcr.io/heptio-images/ks-guestbook-demo:0.1
gcr.io/heptio-images/ks-guestbook-demo:0.2

However, not all the guestbook samples use the same image tag. This pull request (PR) aims to update the ks-guestbook-demo image to version 0.1 on all the samples for consistency. After the initial deployment, users can then update the required YAML to use the 0.2 tag value and observe the different deployment strategies in practice.

Additionally, the **replicaCount** has been updated to 3 (quorum) instead of 1, as having 3 replicas will better demonstrate the execution strategies in action.