### PR TITLE
Add namespace to manifest files for GitOps guide/workshop.

### DIFF
--- a/workshop-guestbook/guestbook-ui-deployment.yaml
+++ b/workshop-guestbook/guestbook-ui-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: guestbook-ui
+  namespace: guestbook
+spec:
+  replicas: 3
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: guestbook-ui
+  template:
+    metadata:
+      labels:
+        app: guestbook-ui
+    spec:
+      containers:
+      - image: gcr.io/heptio-images/ks-guestbook-demo:0.1
+        name: guestbook-ui
+        ports:
+        - containerPort: 80

--- a/workshop-guestbook/guestbook-ui-svc.yaml
+++ b/workshop-guestbook/guestbook-ui-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1	
+kind: Service	
+metadata:	
+  name: guestbook-ui
+  namespace: guestbook	
+spec:	
+  ports:	
+  - port: 80	
+    targetPort: 80	
+  selector:	
+    app: guestbook-ui

--- a/workshop-guestbook/kustomization.yaml
+++ b/workshop-guestbook/kustomization.yaml
@@ -1,0 +1,7 @@
+namePrefix: kustomize-
+
+resources:
+- guestbook-ui-deployment.yaml
+- guestbook-ui-svc.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Due to an update in the Kustomization Controller, the vanilla yamls need to have namespace in them, this works without namespace in ArgoCD.

Without adding this namespace field, the GitOps application fails to become healthy. 

Proposing to add a separate directory for this workaround rather than changing existing guestbook directories.