### PR TITLE
Update artifactory-connector.yml

### DIFF
--- a/vm-pdc/ssh/artifactory-connector.yml
+++ b/vm-pdc/ssh/artifactory-connector.yml
@@ -5,7 +5,7 @@ connector:
   projectIdentifier: default_project
   type: Artifactory
   spec:
-    artifactoryServerUrl: https://harness.jfrog.io/artifactory
+    artifactoryServerUrl: https://harness-artifactory-ovh.harness.io/artifactory
     auth:
       type: Anonymous
     executeOnDelegate: false


### PR DESCRIPTION
The previous artifactory repo has been decommissioned so the pipeline fails due not finding the WAR. This new repo contains the necessary artifact.